### PR TITLE
Add anime support and venue-aware discussion routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Discussio - Stremio Discussion Finder
 
-A simple yet powerful Stremio addon that helps you find discussions with one click. Whether you're watching a TV show episode or a movie, simply click the addon to open a Google search for relevant discussions.
+A Stremio addon that takes you to the discussion for whatever you're watching in one click. Pick an episode or a movie, and Discussio sends you straight to where people are actually talking about it — the right venue for the kind of content, not a generic web search.
 
 ![Stremio Badge](https://img.shields.io/badge/Stremio-Addon-red.svg)
-![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)
+![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)
 
 ## 🚀 Features
 
-- One-click access to discussions for both TV shows and movies
-- Works with any TV series or movie on Stremio
-- Metadata sourced from **Cinemeta** (Stremio's official metadata addon) — no more broken titles
-- Episode titles included in series searches for sharper results
-- Specialized search queries for optimal results
+- One-click discussions for anime, TV series, and movies
+- **Venue-aware routing** — each content type points at where its discussion really lives:
+  - **Anime** → the [r/anime](https://reddit.com/r/anime) episode/film discussion thread (the largest anime community)
+  - **TV series** → the show's own subreddit episode-discussion thread (found via Google across Reddit)
+  - **Movies** → the film's [Letterboxd](https://letterboxd.com) page — straight to thousands of persistent reviews & comments, no search hop
+- **First-class anime support** — works with both Kitsu ids (`kitsu:`) and anime that Stremio serves under IMDB ids, which are auto-detected and routed to r/anime
+- Titles resolved from **Cinemeta** (live-action / IMDB) and the **Kitsu** addon (anime) — English titles preferred for sharper anime results
 - Public anonymous stats page (`/stats`) — no PII, just request counts
-- Fast and lightweight, in-process LRU cache + persistent Deno KV counters
+- Fast and lightweight: in-process LRU + negative cache, optional persistent Deno KV counters
 - No configuration needed
 
 ## 📦 Installation
@@ -34,28 +36,53 @@ Hosted free of charge by [ElfHosted](https://elfhosted.com).
 git clone https://github.com/yourusername/discussio.git
 cd discussio
 deno task dev
-# Then in Stremio, add: http://127.0.0.1:7000/manifest.json
+# Then in Stremio (desktop app), add: http://127.0.0.1:7000/manifest.json
 ```
+
+> Use the Stremio **desktop** app for local testing — the web app is served over
+> HTTPS and blocks `http://localhost` addons (mixed content).
 
 ## 🎯 How to Use
 
-### For TV Shows
+### Anime
 
-1. Open any TV series in Stremio
-2. Select a season and episode you want to discuss
-3. Click the "Streams" button
-4. Find "Search Episode Discussions" in the list
-5. Click to open Google search results for that episode
+1. Open any anime in Stremio and pick an episode (or open an anime film)
+2. Open the **Streams** list
+3. Click **Search Episode Discussions** → lands on the r/anime discussion thread
 
-### For Movies
+Works whether the anime is provided under a Kitsu id or an IMDB id — Discussio
+detects anime either way.
 
-1. Open any movie in Stremio
-2. Click the "Streams" button
-3. Click "Search Movie Discussions"
+### TV Shows
 
-The search will automatically include:
-- The movie's release year (when available)
-- Results from Reddit, Letterboxd, and general film discussion forums
+1. Open a series, select a season and episode
+2. Open the **Streams** list → **Search Episode Discussions**
+3. Opens a Reddit search tuned to the show's own episode-discussion thread
+   (uses season/episode plus the episode title, which is how those threads are titled)
+
+### Movies
+
+1. Open a movie → open the **Streams** list
+2. Click **Movie Discussion · Letterboxd**
+3. Teleports directly to the film's Letterboxd page (reviews + comments)
+
+## 🧠 How routing works
+
+| Content | Destination | Method |
+|---|---|---|
+| Anime episode / film | r/anime thread | Google scoped to `site:reddit.com/r/anime` |
+| TV series episode | show's subreddit thread | Google scoped to `site:reddit.com` |
+| Movie | Letterboxd film page | direct deep-link, no search |
+
+**Anime detection:** ids prefixed `kitsu:` / `mal:` / `anilist:` / `anidb:` are
+anime by definition. IMDB-id content is treated as anime when its Cinemeta
+metadata is animation *and* originates from Japan — so Japanese anime served
+under `tt` ids reaches r/anime, while Western animation does not.
+
+**Movies → Letterboxd:** for catalog films, Letterboxd holds far more persistent
+engagement than a long-archived Reddit megathread, and it is deep-linkable by
+both IMDB id (`/imdb/{tt}/`) and TMDB id (`/tmdb/{id}/`) — keyless and
+first-party — so movies need no title lookup at all and TMDB ids resolve for free.
 
 ## 📊 Stats
 
@@ -63,15 +90,24 @@ Anonymous usage counters are exposed at:
 - `https://discussio.elfhosted.com/stats` — human-readable page
 - `https://discussio.elfhosted.com/stats.json` — machine-readable JSON
 
-Tracked: total request count, type breakdown (series vs movie), per-day counts (last 30 days), top requested IMDB IDs (top 25). No IPs, no user agents, no identifiers.
+Tracked: total request count, type breakdown (series vs movie), per-day counts
+(last 30 days), and top requested title ids (top 25). No IPs, no user agents,
+no identifiers.
 
 ## 🛠️ Technical Details
 
 - Built with Deno and TypeScript
-- Uses **Cinemeta** (`https://v3-cinemeta.strem.io`) for title/episode metadata
+- **Metadata registry** maps each id scheme to its meta source, all keyless:
+  - `tt` → **Cinemeta** (`https://v3-cinemeta.strem.io`)
+  - `kitsu` → **Kitsu** addon (`https://anime-kitsu.strem.fun`)
+  - `tmdb` movies → **Letterboxd** id deep-link (no meta fetch needed)
 - Native `Deno.serve` HTTP server (no SDK runtime dependency)
-- LRU + TTL in-memory cache (5000 entries × 24h)
-- Persistent counters via Deno KV (falls back to memory if unavailable)
+- LRU + TTL in-memory cache (5000 entries × 24h) + short negative cache
+- Persistent counters via Deno KV when available (run with `--unstable-kv`),
+  falls back to in-memory
+- The manifest is served `no-cache` so capability changes (types / `idPrefixes`)
+  are never hidden behind a stale cached copy in Stremio
+- `idPrefixes`: `tt`, `kitsu:`
 - Default port: `7000` (override with `PORT` env var)
 - Log level via `LOG_LEVEL` env var (`0`=debug, `1`=info, `2`=warn, `3`=error)
 
@@ -81,20 +117,29 @@ Tracked: total request count, type breakdown (series vs movie), per-day counts (
 |------|-------------|
 | `/` | Landing page |
 | `/manifest.json` | Stremio addon manifest |
-| `/stream/series/:id.json` | Stream handler for series episodes |
-| `/stream/movie/:id.json` | Stream handler for movies |
+| `/stream/series/:id.json` | Stream handler for series / anime episodes |
+| `/stream/movie/:id.json` | Stream handler for movies / anime films |
 | `/stats` | Public stats page |
 | `/stats.json` | Public stats JSON |
 | `/healthz` | Health check |
 
-## 🔧 What Changed in 1.1.0
+## 🔧 What Changed in 1.2.0
 
-- **Fixed**: Titles showing as raw IMDB IDs (e.g. `tt31889371`) — IMDB changed their HTML, breaking the old scraper. Replaced with Cinemeta.
-- **Fixed**: Discussio entry sometimes missing entirely — addon now always emits a stream, falling back to an IMDB-ID-based search when metadata lookup fails (rare/new titles, Cinemeta hiccups).
-- **Added**: Episode titles in series search queries.
-- **Added**: `/stats` and `/stats.json` endpoints.
-- **Added**: Bounded LRU cache + negative cache (avoids retry storms on bad IDs).
-- **Changed**: Native `Deno.serve` router replaces SDK runtime — fewer deps, more control.
+- **Added**: anime support. Anime never reached the addon before because the
+  manifest only claimed IMDB (`tt`) ids; it now also claims `kitsu:` ids and
+  resolves anime titles via the Kitsu addon.
+- **Added**: anime auto-detection for anime served under IMDB ids (Japanese
+  animation), routing it to r/anime instead of treating it as a Western series.
+- **Changed**: discussion routing is now venue-aware — anime → r/anime, TV →
+  the show's subreddit, movies → Letterboxd — replacing the single generic
+  Google search.
+- **Changed**: movies teleport straight to their Letterboxd film page (IMDB or
+  TMDB id), with no title lookup; TMDB ids resolve for free.
+- **Changed**: series queries use natural-language numbering plus the episode
+  title to better match how subreddit threads are titled.
+- **Fixed**: the manifest is now served `no-cache`. A previous 24h cache header
+  caused Stremio to keep an addon's old capabilities, silently dropping newly
+  supported content (this is what hid anime support).
 
 ## ⚙️ Configuration
 

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1,9 +1,18 @@
 // Discussio — Stremio addon for one-click discussion search.
 // Uses Cinemeta (Stremio's official metadata addon) instead of scraping IMDB.
 
-const VERSION = "1.1.0";
+const VERSION = "1.2.0";
 const MANIFEST_URL = "https://discussio.elfhosted.com/manifest.json";
 const CINEMETA_BASE = "https://v3-cinemeta.strem.io/meta";
+const KITSU_BASE = "https://anime-kitsu.strem.fun/meta";
+
+// Maps a content-id scheme to the Stremio meta addon that resolves it.
+// All sources speak the same /meta/{type}/{id}.json shape and need no API key.
+// Schemes absent here (e.g. "tmdb") fall back to an id-based search query.
+const META_SOURCES: Record<string, string> = {
+  tt: CINEMETA_BASE,
+  kitsu: KITSU_BASE,
+};
 const TITLE_CACHE_MAX = 5000;
 const TITLE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -55,7 +64,7 @@ const MANIFEST = {
   logo: "https://api.logo.com/api/v2/images?design=lg_aiGdQc9PParm0yrELH&width=250&height=250&fit=contain&margin_ratio=0&background=%23294fff&u=2025-02-19T10%3A24%3A54.398Z&format=png&quality=30",
   resources: ["stream"],
   types: ["series", "movie"],
-  idPrefixes: ["tt"],
+  idPrefixes: ["tt", "kitsu:"],
   catalogs: [],
   behaviorHints: {
     configurable: false,
@@ -75,6 +84,9 @@ interface CinemetaVideo {
 interface CinemetaMeta {
   id: string;
   name: string;
+  aliases?: string[];
+  genres?: string[];
+  country?: string;
   year?: string;
   releaseInfo?: string;
   videos?: CinemetaVideo[];
@@ -128,10 +140,16 @@ function markFailure(key: string): void {
 }
 
 async function fetchMeta(
+  scheme: string,
   type: "series" | "movie",
-  imdbId: string,
+  metaId: string,
 ): Promise<CinemetaMeta | null> {
-  const cacheKey = `${type}:${imdbId}`;
+  const baseUrl = META_SOURCES[scheme];
+  if (!baseUrl) {
+    logger.info(`No meta source for scheme "${scheme}" (${metaId})`);
+    return null;
+  }
+  const cacheKey = `${type}:${metaId}`;
   const cached = cacheGet(cacheKey);
   if (cached) return cached;
   if (isNegativeCached(cacheKey)) return null;
@@ -139,20 +157,20 @@ async function fetchMeta(
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), CINEMETA_TIMEOUT_MS);
   try {
-    const url = `${CINEMETA_BASE}/${type}/${imdbId}.json`;
+    const url = `${baseUrl}/${type}/${metaId}.json`;
     const res = await fetch(url, {
       signal: controller.signal,
       headers: { "Accept": "application/json" },
     });
     if (!res.ok) {
-      logger.warn(`Cinemeta ${res.status} for ${imdbId}`);
+      logger.warn(`Meta ${res.status} for ${metaId}`);
       markFailure(cacheKey);
       return null;
     }
     const data = await res.json();
     const meta: CinemetaMeta | undefined = data?.meta;
     if (!meta?.name) {
-      logger.warn(`Cinemeta empty meta for ${imdbId}`);
+      logger.warn(`Empty meta for ${metaId}`);
       markFailure(cacheKey);
       return null;
     }
@@ -160,9 +178,9 @@ async function fetchMeta(
     return meta;
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      logger.warn(`Cinemeta timeout for ${imdbId}`);
+      logger.warn(`Meta timeout for ${metaId}`);
     } else {
-      logger.error(`Cinemeta error for ${imdbId}:`, err);
+      logger.error(`Meta error for ${metaId}:`, err);
     }
     markFailure(cacheKey);
     return null;
@@ -171,36 +189,151 @@ async function fetchMeta(
   }
 }
 
-function findEpisode(
-  meta: CinemetaMeta,
-  season: number,
-  episode: number,
-): CinemetaVideo | undefined {
-  if (!meta.videos) return undefined;
-  return meta.videos.find(
-    (v) =>
-      v.season === season &&
-      (v.episode === episode || v.number === episode),
-  );
+
+interface ParsedSeriesId {
+  scheme: string;
+  metaId: string;
+  season: number;
+  episode: number;
 }
 
-function buildSeriesQuery(
+// Splits a Stremio series stream id into scheme + meta id + season/episode.
+// Handles both colon-free schemes (tt: "tt123:1:5") and colon-prefixed ones
+// (kitsu: "kitsu:46043:5", where the id itself contains a colon). Anime ids use
+// absolute episode numbering with no season segment, so season defaults to 1.
+function parseSeriesId(rawId: string): ParsedSeriesId | null {
+  const parts = rawId.split(":");
+  let scheme: string;
+  let metaId: string;
+  let rest: string[];
+  if (/^tt\d+$/.test(parts[0])) {
+    scheme = "tt";
+    metaId = parts[0];
+    rest = parts.slice(1);
+  } else if (parts.length >= 2) {
+    scheme = parts[0];
+    metaId = `${parts[0]}:${parts[1]}`;
+    rest = parts.slice(2);
+  } else {
+    return null;
+  }
+  if (rest.length >= 2) {
+    const season = Number(rest[0]);
+    const episode = Number(rest[1]);
+    if (!Number.isFinite(season) || !Number.isFinite(episode)) return null;
+    return { scheme, metaId, season, episode };
+  }
+  if (rest.length === 1) {
+    const episode = Number(rest[0]);
+    if (!Number.isFinite(episode)) return null;
+    return { scheme, metaId, season: 1, episode };
+  }
+  return null;
+}
+
+function parseMovieId(
+  rawId: string,
+): { scheme: string; metaId: string } | null {
+  const parts = rawId.split(":");
+  if (/^tt\d+$/.test(parts[0])) return { scheme: "tt", metaId: parts[0] };
+  if (parts.length >= 2) {
+    return { scheme: parts[0], metaId: `${parts[0]}:${parts[1]}` };
+  }
+  return null;
+}
+
+// Picks the best title for the Google query. Cinemeta (tt) names are already
+// English. Anime metas carry the native/romaji name plus an aliases list; the
+// first latin-script alias is usually the official English title, which gives
+// far better discussion-search results than romaji.
+function pickTitle(meta: CinemetaMeta, scheme: string): string {
+  if (scheme === "tt") return meta.name;
+  const alias = meta.aliases?.find(
+    (a) => /[a-z]/i.test(a) && a !== meta.name,
+  );
+  return alias ?? meta.name;
+}
+
+// Detects anime so tt-id anime (Cinemeta serves most anime under IMDB ids, not
+// kitsu) gets routed to r/anime instead of being treated as a western series.
+// kitsu/mal/anilist/anidb ids are anime by definition; for tt ids we use the
+// reliable Cinemeta signal: Japanese-country animation.
+const ANIME_SCHEMES = new Set(["kitsu", "mal", "anilist", "anidb"]);
+
+function isAnime(meta: CinemetaMeta | null, scheme: string): boolean {
+  if (ANIME_SCHEMES.has(scheme)) return true;
+  if (scheme !== "tt" || !meta) return false;
+  return (meta.genres?.includes("Animation") ?? false) &&
+    meta.country === "Japan";
+}
+
+function googleUrl(query: string): string {
+  return `https://www.google.com/search?q=${encodeURIComponent(query)}`;
+}
+
+// The goal of every query is to surface the single highest-engagement Reddit
+// discussion thread. Google (not Reddit's own search) ranks these well, so we
+// scope the query to the subreddit where that thread lives.
+
+// Anime episodes: r/anime hosts the largest per-episode discussion threads,
+// titled "<Title> - Episode <N> discussion". Season prefix only when > 1, since
+// most r/anime entries number a single cour from episode 1.
+function buildAnimeEpisodeQuery(
+  title: string,
+  season: number,
+  episode: number,
+): string {
+  const seasonPart = season > 1 ? `season ${season} ` : "";
+  return `${title} ${seasonPart}episode ${episode} discussion site:reddit.com/r/anime`;
+}
+
+// Western series episodes live in the show's own subreddit, whose name we can't
+// derive — so we let Google find it across all of Reddit. Number formats vary by
+// sub (1x04 / S01E04 / "Season 1 Episode 4"), so we use natural-language
+// numbering (Google normalizes it) and lean on the episode title, which is the
+// unique token those threads are titled with, e.g.
+//   Severance - 1x04 "The You You Are" - Episode Discussion
+function buildSeriesEpisodeQuery(
   title: string,
   season: number,
   episode: number,
   episodeTitle?: string,
 ): string {
-  const ep = episodeTitle ? ` "${episodeTitle}"` : "";
-  return encodeURIComponent(
-    `${title} Season ${season} Episode ${episode}${ep} discussion`,
-  );
+  const ep = episodeTitle ? ` ${episodeTitle}` : "";
+  return `${title} season ${season} episode ${episode}${ep} discussion site:reddit.com`;
 }
 
-function buildMovieQuery(title: string, year?: string): string {
-  const yearSuffix = year ? ` (${year})` : "";
-  return encodeURIComponent(
-    `${title}${yearSuffix} movie discussion reddit OR letterboxd OR "movie discussion" OR "film discussion"`,
+// Pulls an episode's title from the meta's videos list (Cinemeta provides it for
+// western series). Used only to sharpen the Reddit query, so a miss is harmless.
+function findEpisodeTitle(
+  meta: CinemetaMeta,
+  season: number,
+  episode: number,
+): string | undefined {
+  const v = meta.videos?.find(
+    (v) => v.season === season && (v.episode === episode || v.number === episode),
   );
+  return v?.title ?? v?.name;
+}
+
+// Anime films: discussion lives in r/anime alongside everything else anime.
+function buildAnimeMovieQuery(title: string, year: string | undefined): string {
+  const yearSuffix = year ? ` (${year})` : "";
+  return `${title}${yearSuffix} movie discussion site:reddit.com/r/anime`;
+}
+
+// Non-anime movies link straight to the film's Letterboxd page. For catalog
+// films (the typical Stremio case) Letterboxd holds far more persistent
+// engagement than a long-archived Reddit megathread, and it is keyless,
+// first-party, and deep-linkable by either imdb or tmdb id — so no title lookup
+// is needed and tmdb resolves for free.
+function letterboxdFilmUrl(scheme: string, metaId: string): string | null {
+  if (scheme === "tt") return `https://letterboxd.com/imdb/${metaId}/`;
+  if (scheme === "tmdb") {
+    const id = metaId.split(":")[1];
+    if (id) return `https://letterboxd.com/tmdb/${id}/`;
+  }
+  return null;
 }
 
 // ===== Metrics =====
@@ -348,61 +481,86 @@ async function handleStream(
   id: string,
 ): Promise<{ streams: Stream[] }> {
   if (type === "series") {
-    const match = id.match(/^(tt\d+):(\d+):(\d+)$/);
-    if (!match) {
+    const parsed = parseSeriesId(id);
+    if (!parsed) {
       logger.warn("Invalid series id", { id });
       return { streams: [] };
     }
-    const [, imdbId, seasonStr, episodeStr] = match;
-    const season = Number(seasonStr);
-    const episode = Number(episodeStr);
-    const meta = await fetchMeta("series", imdbId);
-    recordRequest("series", imdbId).catch(() => {});
+    const { scheme, metaId, season, episode } = parsed;
+    const meta = await fetchMeta(scheme, "series", metaId);
+    recordRequest("series", metaId).catch(() => {});
     let title: string;
-    let episodeTitle: string | undefined;
     if (meta) {
-      title = meta.name;
-      const epInfo = findEpisode(meta, season, episode);
-      episodeTitle = epInfo?.title ?? epInfo?.name;
+      title = pickTitle(meta, scheme);
     } else {
-      title = imdbId;
-      logger.info(`Series fallback for ${imdbId} S${season}E${episode} (no meta)`);
+      title = metaId;
+      logger.info(`Series fallback for ${metaId} S${season}E${episode} (no meta)`);
     }
-    const query = buildSeriesQuery(title, season, episode, episodeTitle);
+    let query: string;
+    if (isAnime(meta, scheme)) {
+      query = buildAnimeEpisodeQuery(title, season, episode);
+    } else {
+      const episodeTitle = meta
+        ? findEpisodeTitle(meta, season, episode)
+        : undefined;
+      query = buildSeriesEpisodeQuery(title, season, episode, episodeTitle);
+    }
     return {
       streams: [{
         name: "Discussio",
         title: "Search Episode Discussions",
-        externalUrl: `https://www.google.com/search?q=${query}`,
+        externalUrl: googleUrl(query),
         behaviorHints: { notWebReady: false },
       }],
     };
   }
 
   if (type === "movie") {
-    const match = id.match(/^(tt\d+)$/);
-    if (!match) {
+    const parsed = parseMovieId(id);
+    if (!parsed) {
       logger.warn("Invalid movie id", { id });
       return { streams: [] };
     }
-    const [, imdbId] = match;
-    const meta = await fetchMeta("movie", imdbId);
-    recordRequest("movie", imdbId).catch(() => {});
-    let title: string;
-    let year: string | undefined;
-    if (meta) {
-      title = meta.name;
-      year = meta.year ?? meta.releaseInfo?.match(/\d{4}/)?.[0];
-    } else {
-      title = imdbId;
-      logger.info(`Movie fallback for ${imdbId} (no meta)`);
+    const { scheme, metaId } = parsed;
+    // tt is fetched only to detect anime (Cinemeta serves anime films too);
+    // tmdb has no meta source and resolves to null → non-anime → Letterboxd.
+    const meta = await fetchMeta(scheme, "movie", metaId);
+    recordRequest("movie", metaId).catch(() => {});
+
+    if (isAnime(meta, scheme)) {
+      const title = meta ? pickTitle(meta, scheme) : metaId;
+      const year = meta?.year?.match(/\d{4}/)?.[0] ??
+        meta?.releaseInfo?.match(/\d{4}/)?.[0];
+      return {
+        streams: [{
+          name: "Discussio",
+          title: "Search Movie Discussions",
+          externalUrl: googleUrl(buildAnimeMovieQuery(title, year)),
+          behaviorHints: { notWebReady: false },
+        }],
+      };
     }
-    const query = buildMovieQuery(title, year);
+
+    // Non-anime movie → teleport straight to the Letterboxd film page.
+    const letterboxd = letterboxdFilmUrl(scheme, metaId);
+    if (letterboxd) {
+      return {
+        streams: [{
+          name: "Discussio",
+          title: "Movie Discussion · Letterboxd",
+          externalUrl: letterboxd,
+          behaviorHints: { notWebReady: false },
+        }],
+      };
+    }
+
+    // Unknown scheme with no Letterboxd id — last-resort id search.
+    logger.info(`Movie fallback for ${metaId} (no Letterboxd id)`);
     return {
       streams: [{
         name: "Discussio",
         title: "Search Movie Discussions",
-        externalUrl: `https://www.google.com/search?q=${query}`,
+        externalUrl: googleUrl(`${metaId} movie discussion`),
         behaviorHints: { notWebReady: false },
       }],
     };
@@ -564,13 +722,21 @@ Deno.serve({
 }, async (req) => {
   const url = new URL(req.url);
   const path = url.pathname;
+  logger.debug(`REQ ${req.method} ${path}`);
 
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
 
   if (path === "/") return htmlResponse(renderLanding());
-  if (path === "/manifest.json") return jsonResponse(MANIFEST);
+  if (path === "/manifest.json") {
+    // Never cache the manifest: Stremio keys an addon's capabilities (types,
+    // idPrefixes) off it, so a stale cached copy silently drops content the
+    // addon now supports. A 24h cache here previously hid the kitsu support.
+    return jsonResponse(MANIFEST, {
+      headers: { "Cache-Control": "no-cache, no-store, must-revalidate" },
+    });
+  }
   if (path === "/healthz") {
     return new Response("ok", {
       headers: { "Content-Type": "text/plain", ...CORS_HEADERS },


### PR DESCRIPTION
## Why
Anime never reached the addon — the manifest only claimed `tt` ids, so Stremio never queried Discussio for `kitsu:` content. And every content type got the same generic Google search regardless of where its discussion actually lives.

## What changed
- **Anime support**: claim `kitsu:` ids, resolve titles via the Kitsu addon, prefer English title.
- **Anime auto-detection** for anime served under IMDB ids (Japanese animation) → routes to r/anime, while Western animation stays a series.
- **Venue-aware routing**:
  - anime episode/film → r/anime thread (`site:reddit.com/r/anime`)
  - TV episode → show's subreddit thread (`site:reddit.com`), keyed on natural-language numbering + episode title
  - movie → teleport straight to the Letterboxd film page (imdb/tmdb id), no title lookup; tmdb resolves for free
- **Manifest `no-cache`**: a 24h cache header made Stremio keep an addon's old capabilities, silently hiding newly supported content (this is what hid anime).
- Bump to 1.2.0; README rewritten to match.

## Testing
Verified live in the Stremio desktop app and via direct endpoint calls across kitsu/tt/tmdb ids for anime, Western series, Western animation (correctly excluded), and movies. `deno check` + `deno lint` clean.